### PR TITLE
Feature/custom name for generated datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,12 @@ Generate training data using ChatGPT4 model for a project given a configuration 
 
 Options:
   --project <project>  The name of the project. This project must exist under `./projects/{name}/ with an `oaift.config.json` file.
-  --apply              Apply the data generation (there will be costs associated). To only preview the chat completion templates, call this command without the `--apply` flag.
+  --apply              Apply the data generation (there will be costs associated). To only preview the chat completion templates,
+                       call this command without the `--apply` flag.
+  --name <name>        Your own custom name for the dataset that will be generated. If this value is not passed in, the default
+                       value is {project}-{unixtime}
+  --force              Used in conjunction with the '--name' flag. If there is a dataset name conflict, it will cancel the process
+                       by default. Add this flag to force the generation which will overwrite existing files.
   -h, --help           display help for command
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,14 @@ program
     "--apply",
     "Apply the data generation (there will be costs associated). To only preview the chat completion templates, call this command without the `--apply` flag."
   )
+  .option(
+    "--name <name>",
+    "Your own custom name for the dataset that will be generated. If this value is not passed in, the default value is {project}-{unixtime}"
+  )
+  .option(
+    "--force",
+    "Used in conjunction with the '--name' flag. If there is a dataset name conflict, it will cancel the process by default. Add this flag to force the generation which will overwrite existing files."
+  )
   .action(async (opt: GenerateOptions) => {
     await validateProjectExists(opt.project);
     const cmd = new GenerateCmd(opt, oai);

--- a/src/processors/FineTuneCmd.ts
+++ b/src/processors/FineTuneCmd.ts
@@ -2,10 +2,12 @@ import fs from "fs";
 import path from "path";
 import fsPromise from "fs/promises";
 import OpenAI from "openai";
-import { OaiConfig, getProjectConfig } from "../types/config";
+import { getProjectConfig } from "../types/config";
 import { ChatCompletionCreateParams } from "openai/resources";
 import { spawn } from "child_process";
 import { DEFAULT_MODEL } from "../constants/openai";
+import { info, log } from "console";
+import { prettifyJson } from "../utils/log";
 
 export type FineTuneOptions = {
   project: string;
@@ -27,8 +29,8 @@ export class FineTuneCmd {
     const data = await this.previewJobReport(
       `${projectJobPath}/training_set.jsonl`
     );
-    console.info("-----Preview-----");
-    console.log(data);
+    info("-----Preview-----");
+    info(data);
     await fsPromise.writeFile(`${projectJobPath}/fine_tune_preview.txt`, data);
     if (this.opts.apply) {
       const data = await this.createFineTuneJob(
@@ -36,22 +38,20 @@ export class FineTuneCmd {
       );
       await fsPromise.writeFile(
         `${projectJobPath}/fine_tuning_${data.job.id}.json`,
-        JSON.stringify(data, null, 2)
+        prettifyJson(data)
       );
     }
   }
 
   public async createFineTuneJob(trainingFilePath: string) {
     const config = await getProjectConfig(this.opts.project);
-    console.info(`Uploading fine tuning training file: ${trainingFilePath}`);
+    info(`Uploading fine tuning training file: ${trainingFilePath}`);
     const trainingFile = await this.oai.files.create({
       file: fs.createReadStream(trainingFilePath),
       purpose: "fine-tune",
     });
 
-    console.info(
-      `Starting fine tuning job with training file ID: ${trainingFile.id}`
-    );
+    info(`Starting fine tuning job with training file ID: ${trainingFile.id}`);
     const job = await this.oai.fineTuning.jobs.create({
       model: config.model || DEFAULT_MODEL,
       training_file: trainingFile.id,
@@ -73,12 +73,12 @@ export class FineTuneCmd {
       ]);
 
       python.stdout.on("data", function (data) {
-        console.info("Initializing python script to preview training...");
+        info("Initializing python script to preview training...");
         resolve(data.toString());
       });
 
       python.on("error", (err) => {
-        console.log("Err: ", err);
+        log("Err: ", err);
         reject(err);
       });
     });

--- a/src/processors/FineTuneCmd.ts
+++ b/src/processors/FineTuneCmd.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import fsPromise from "fs/promises";
 import OpenAI from "openai";
-import { OaiConfig } from "../types/config";
+import { OaiConfig, getProjectConfig } from "../types/config";
 import { ChatCompletionCreateParams } from "openai/resources";
 import { spawn } from "child_process";
 import { DEFAULT_MODEL } from "../constants/openai";
@@ -42,7 +42,7 @@ export class FineTuneCmd {
   }
 
   public async createFineTuneJob(trainingFilePath: string) {
-    const config = await this.getProjectConfig();
+    const config = await getProjectConfig(this.opts.project);
     console.info(`Uploading fine tuning training file: ${trainingFilePath}`);
     const trainingFile = await this.oai.files.create({
       file: fs.createReadStream(trainingFilePath),
@@ -82,13 +82,5 @@ export class FineTuneCmd {
         reject(err);
       });
     });
-  }
-
-  private async getProjectConfig() {
-    const config = await fsPromise.readFile(
-      `./projects/${this.opts.project}/oaift.config.json`,
-      "utf-8"
-    );
-    return JSON.parse(config) as OaiConfig;
   }
 }

--- a/src/processors/FineTuneCmd.ts
+++ b/src/processors/FineTuneCmd.ts
@@ -15,11 +15,9 @@ export type FineTuneOptions = {
 };
 
 export class FineTuneCmd {
-  private batchSize: number;
   private opts: FineTuneOptions;
   private oai: OpenAI;
   constructor(opts: FineTuneOptions, oai: OpenAI) {
-    this.batchSize = 3;
     this.opts = opts;
     this.oai = oai;
   }
@@ -52,7 +50,7 @@ export class FineTuneCmd {
     });
 
     console.info(
-      `Startiing fine tuning job with training file ID: ${trainingFile.id}`
+      `Starting fine tuning job with training file ID: ${trainingFile.id}`
     );
     const job = await this.oai.fineTuning.jobs.create({
       model: config.model || DEFAULT_MODEL,

--- a/src/processors/GenerateCmd.ts
+++ b/src/processors/GenerateCmd.ts
@@ -49,9 +49,7 @@ export class GenerateCmd {
       console.info(
         `Processing data generation batch ${counter} / ${batches.length}`
       );
-      const output = await Promise.all(
-        batch.map((config) => this.completeChat(config))
-      );
+      const output = await Promise.all(batch.map(this.completeChat));
       completions.push(...output);
       counter += 1;
     }
@@ -68,13 +66,15 @@ export class GenerateCmd {
   }
 
   private async completeChat(
-    messageConfig: ChatCompletionCreateParams
+    messageConfig: ChatCompletionCreateParams,
+    i: number
   ): Promise<ChatCompletion> {
+    console.info(`Generating chat completion #${i}...`);
     const response = (await this.oai.chat.completions.create({
       ...messageConfig,
       function_call: "auto",
       functions: oaiFn.definitions,
-      temperature: 0,
+      temperature: 0.5,
       stream: false,
     })) as ChatCompletion;
     return response;

--- a/src/processors/JobsCmd.ts
+++ b/src/processors/JobsCmd.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { info, log, prettifyJson } from "../utils/log";
 
 export type JobListOptions = {
   id: string;
@@ -25,33 +26,33 @@ export class JobsCmd {
   public async events(opts: JobEventsOptions) {
     const events = await this.oai.fineTunes.listEvents(opts.id);
     events.data.forEach((event, i) => {
-      console.log(`----${i + 1}----`);
-      console.info(`Level: ${event.level} | CreatedAt: ${event.created_at}`);
-      console.info(`Message: ${event.message}`);
-      console.info(`Details: ${JSON.stringify(event.object, null, 2)}`);
+      log(`----${i + 1}----`);
+      info(`Level: ${event.level} | CreatedAt: ${event.created_at}`);
+      info(`Message: ${event.message}`);
+      info(`Details: ${prettifyJson(event.object as any)}`);
     });
   }
 
   private async listOne(id: string) {
     const job = await this.oai.fineTunes.retrieve(id);
-    console.info(
+    info(
       `ID: ${job.id} | Model: ${job.model} | FineTunedModel: ${job.fine_tuned_model}`
     );
 
     const trainingFileIds = job.training_files.map((file) => file.id);
-    console.info(`Status: ${job.status} | TrainingFiles: ${trainingFileIds}`);
+    info(`Status: ${job.status} | TrainingFiles: ${trainingFileIds}`);
   }
 
   private async listAll() {
     const jobList = await this.oai.fineTunes.list();
     jobList.data.forEach((job, i) => {
-      console.log(`----${i + 1}----`);
-      console.info(
+      log(`----${i + 1}----`);
+      info(
         `ID: ${job.id} | Model: ${job.model} | FineTunedModel: ${job.fine_tuned_model}`
       );
 
       const trainingFileIds = job.training_files.map((file) => file.id);
-      console.info(`Status: ${job.status} | TrainingFiles: ${trainingFileIds}`);
+      info(`Status: ${job.status} | TrainingFiles: ${trainingFileIds}`);
     });
   }
 }

--- a/src/processors/ProjectCmd.ts
+++ b/src/processors/ProjectCmd.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
 import configTemplate from "../templates/oaift-template.config.json";
+import { prettifyJson } from "../utils/log";
 
 export type ProjectCmdOptions = {
   name: string;
@@ -38,7 +39,7 @@ export class ProjectCmd {
 
     await fs.writeFile(
       `${projectPath}/oaift.config.json`,
-      JSON.stringify(configTemplate, null, 2)
+      prettifyJson(configTemplate)
     );
   }
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,3 +1,4 @@
+import fs from "fs/promises";
 import { ChatCompletionCreateParams } from "openai/resources";
 import { z } from "zod";
 
@@ -18,3 +19,11 @@ export const OaiConfigSchema = z.object({
   template: z.string(),
   model: z.string(),
 });
+
+export const getProjectConfig = async (project: string): Promise<OaiConfig> => {
+  const config = await fs.readFile(
+    `./projects/${project}/oaift.config.json`,
+    "utf-8"
+  );
+  return JSON.parse(config) as OaiConfig;
+};

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,0 +1,7 @@
+export const log = console.log;
+export const info = console.info;
+export const warn = console.warn;
+export const error = console.error;
+
+export const prettifyJson = (json: Record<string, any>) =>
+  JSON.stringify(json, null, 2);


### PR DESCRIPTION
Supports custom names for data sets within projects.
Custom name conflicts will require `--force` flag for the generate command to proceed.
If `--force` is not present, the generation cannot be applied.